### PR TITLE
fix(email): harden queue notifications and clarify failed-send stats

### DIFF
--- a/app/actions/notifications.ts
+++ b/app/actions/notifications.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { inspect } from "node:util";
 import { createClient } from "@/lib/supabase/server";
 import {
   sendQueueJoinEmail,
@@ -9,14 +10,137 @@ import {
   type QueueEmailData,
 } from "@/lib/email/resend";
 import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
+import { runWithConcurrency } from "@/lib/run-with-concurrency";
+import { isActionableDeliveryFailure } from "@/lib/email/email-delivery-log";
 
 const CENTRAL_TZ = "America/Chicago";
+const QUEUE_EMAIL_CONCURRENCY = 3;
+
+export type NotificationType =
+  | "join"
+  | "position-update"
+  | "up-next"
+  | "court-assignment";
+
+export type EmailLogRow = {
+  id: string;
+  user_id: string | null;
+  event_id: string | null;
+  notification_type: string;
+  sent_at: string;
+  success: boolean;
+  error_message: string | null;
+  resend_message_id: string | null;
+  user: { id: string; name: string; email: string } | null;
+  event: { id: string; name: string } | null;
+};
+
+export type GetEmailStatsResult =
+  | { error: string }
+  | {
+      total: number;
+      successful: number;
+      /** Rows where Resend/transport failed after retries — excludes missing email / invalid data. */
+      failed: number;
+      /** Failed logs that are validation/data issues, not delivery attempts. */
+      failedOther: number;
+      byType: Record<string, number>;
+      logs: EmailLogRow[];
+      failedDeliveryLogs: EmailLogRow[];
+    };
+
+/** Serialize Resend / fetch errors without producing `[object Object]` (circular refs, odd SDK shapes). */
+function formatSendError(error: unknown): string {
+  if (error == null) return "Unknown error";
+  if (error instanceof Error) {
+    return error.message || error.name || "Error";
+  }
+  if (typeof error === "string") return error;
+  if (typeof error === "number" || typeof error === "boolean") {
+    return String(error);
+  }
+  if (typeof error === "object") {
+    const o = error as Record<string, unknown>;
+
+    if (typeof o.message === "string" && o.message.length > 0) {
+      return o.message;
+    }
+    if (o.message != null) {
+      return formatSendError(o.message);
+    }
+
+    if (typeof o.error === "string" && o.error.length > 0) {
+      return o.error;
+    }
+    if (o.error != null) {
+      return formatSendError(o.error);
+    }
+
+    const name = typeof o.name === "string" ? o.name : "";
+    const status =
+      typeof o.statusCode === "number"
+        ? o.statusCode
+        : typeof o.status === "number"
+          ? o.status
+          : null;
+    const prefix = [name, status != null ? `HTTP ${status}` : ""]
+      .filter(Boolean)
+      .join(" ");
+
+    try {
+      const s = JSON.stringify(error);
+      if (s !== "{}" && s !== "null") {
+        return prefix ? `${prefix}: ${s}` : s;
+      }
+    } catch {
+      /* circular or non-serializable */
+    }
+
+    const detail = inspect(error, { depth: 6, breakLength: 200 });
+    return prefix ? `${prefix} ${detail}` : detail;
+  }
+  return String(error);
+}
+
+/** Replace useless legacy DB values from older `String(error)` on plain objects. */
+function normalizeStoredErrorMessage(stored: string | null): string | null {
+  if (stored == null) return null;
+  const t = stored.trim();
+  if (
+    t === "[object Object]" ||
+    t === "Error: [object Object]" ||
+    t.endsWith("[object Object]")
+  ) {
+    return "Legacy log: error details were not saved. New sends record readable errors; match this row to Resend by time and recipient, or use Resend.";
+  }
+  return stored;
+}
+
+async function requireAdmin(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+): Promise<{ error: string | null }> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const { data: profile } = await supabase
+    .from("users")
+    .select("is_admin")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile?.is_admin) {
+    return { error: "Unauthorized" };
+  }
+  return { error: null };
+}
 
 export async function sendQueueNotification(
   userId: string,
   eventId: string,
   position: number,
-  notificationType: "join" | "position-update" | "up-next" | "court-assignment",
+  notificationType: NotificationType,
   courtNumber?: number,
 ) {
   const supabase = await createClient();
@@ -90,16 +214,46 @@ export async function sendQueueNotification(
       return { success: false, error: "Invalid notification type" };
   }
 
+  const messageId =
+    result.success && "messageId" in result ? result.messageId : undefined;
+
   await supabase.from("email_logs").insert({
     user_id: userId,
     event_id: eventId,
     notification_type: notificationType,
     sent_at: new Date().toISOString(),
     success: result.success,
-    error_message: result.success ? null : String(result.error),
+    error_message: result.success ? null : formatSendError(result.error),
+    resend_message_id: messageId ?? null,
   });
 
   return result;
+}
+
+/** Await from server actions so serverless runtimes finish sends; limits parallel Resend calls. */
+export async function flushQueueEmailNotifications(
+  items: Array<{
+    userId: string;
+    eventId: string;
+    position: number;
+    notificationType: NotificationType;
+    courtNumber?: number;
+  }>,
+): Promise<void> {
+  if (items.length === 0) return;
+  await runWithConcurrency(
+    items.map(
+      (item) => () =>
+        sendQueueNotification(
+          item.userId,
+          item.eventId,
+          item.position,
+          item.notificationType,
+          item.courtNumber,
+        ),
+    ),
+    QUEUE_EMAIL_CONCURRENCY,
+  );
 }
 
 function calculateEstimatedWait(
@@ -115,23 +269,11 @@ function calculateEstimatedWait(
 
 export async function getEmailStats(
   timeRange: "today" | "week" | "month" | "all" = "week",
-) {
+): Promise<GetEmailStatsResult> {
   const supabase = await createClient();
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return { error: "Not authenticated" };
-
-  const { data: profile } = await supabase
-    .from("users")
-    .select("is_admin")
-    .eq("id", user.id)
-    .single();
-
-  if (!profile?.is_admin) {
-    return { error: "Unauthorized" };
-  }
+  const { error: authError } = await requireAdmin(supabase);
+  if (authError) return { error: authError };
 
   let dateFilter = new Date();
   switch (timeRange) {
@@ -151,7 +293,20 @@ export async function getEmailStats(
 
   const { data: logs, error } = await supabase
     .from("email_logs")
-    .select("*")
+    .select(
+      `
+      id,
+      user_id,
+      event_id,
+      notification_type,
+      sent_at,
+      success,
+      error_message,
+      resend_message_id,
+      user:users!email_logs_user_id_fkey ( id, name, email ),
+      event:events!email_logs_event_id_fkey ( id, name )
+    `,
+    )
     .gte("sent_at", dateFilter.toISOString())
     .order("sent_at", { ascending: false });
 
@@ -159,12 +314,46 @@ export async function getEmailStats(
     return { error: error.message };
   }
 
-  const total = logs?.length || 0;
-  const successful = logs?.filter((log) => log.success).length || 0;
-  const failed = total - successful;
+  const normalizedLogs: EmailLogRow[] = (logs || []).map((row) => {
+    const r = row as {
+      id: string;
+      user_id: string | null;
+      event_id: string | null;
+      notification_type: string;
+      sent_at: string;
+      success: boolean;
+      error_message: string | null;
+      resend_message_id?: string | null;
+      user:
+        | { id: string; name: string; email: string }
+        | { id: string; name: string; email: string }[]
+        | null;
+      event: { id: string; name: string } | { id: string; name: string }[] | null;
+    };
+    const u = r.user;
+    const e = r.event;
+    return {
+      id: r.id,
+      user_id: r.user_id,
+      event_id: r.event_id,
+      notification_type: r.notification_type,
+      sent_at: r.sent_at,
+      success: r.success,
+      error_message: normalizeStoredErrorMessage(r.error_message),
+      resend_message_id: r.resend_message_id ?? null,
+      user: Array.isArray(u) ? u[0] ?? null : u ?? null,
+      event: Array.isArray(e) ? e[0] ?? null : e ?? null,
+    };
+  });
+
+  const total = normalizedLogs.length;
+  const successful = normalizedLogs.filter((log) => log.success).length;
+  const failedDeliveryLogs = normalizedLogs.filter(isActionableDeliveryFailure);
+  const failed = failedDeliveryLogs.length;
+  const failedOther = normalizedLogs.filter((log) => !log.success).length - failed;
 
   const byType =
-    logs?.reduce((acc: Record<string, number>, log) => {
+    normalizedLogs.reduce((acc: Record<string, number>, log) => {
       acc[log.notification_type] = (acc[log.notification_type] || 0) + 1;
       return acc;
     }, {}) || {};
@@ -173,7 +362,140 @@ export async function getEmailStats(
     total,
     successful,
     failed,
+    failedOther,
     byType,
-    logs: logs || [],
+    logs: normalizedLogs,
+    failedDeliveryLogs,
   };
+}
+
+async function findActiveCourtNumber(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  eventId: string,
+  userId: string,
+): Promise<number | null> {
+  const orClause = [1, 2, 3, 4, 5, 6, 7, 8]
+    .map((n) => `player${n}_id.eq.${userId}`)
+    .join(",");
+
+  const { data, error } = await supabase
+    .from("court_assignments")
+    .select("court_number")
+    .eq("event_id", eventId)
+    .is("ended_at", null)
+    .or(orClause)
+    .maybeSingle();
+
+  if (error || data == null) return null;
+  return data.court_number;
+}
+
+export async function resendQueueEmailFromLog(logId: string) {
+  const supabase = await createClient();
+
+  const { error: authError } = await requireAdmin(supabase);
+  if (authError) return { success: false, error: authError };
+
+  const { data: log, error: fetchError } = await supabase
+    .from("email_logs")
+    .select("id, success, user_id, event_id, notification_type")
+    .eq("id", logId)
+    .single();
+
+  if (fetchError || !log) {
+    return { success: false, error: "Log entry not found" };
+  }
+
+  if (log.success) {
+    return { success: false, error: "This send already succeeded" };
+  }
+
+  if (!log.user_id || !log.event_id) {
+    return {
+      success: false,
+      error: "Log entry is missing user or event; cannot resend",
+    };
+  }
+
+  const userId = log.user_id;
+  const eventId = log.event_id;
+  const notificationType = log.notification_type as NotificationType;
+
+  const validTypes: NotificationType[] = [
+    "join",
+    "position-update",
+    "up-next",
+    "court-assignment",
+  ];
+  if (!validTypes.includes(notificationType)) {
+    return { success: false, error: "Unknown notification type" };
+  }
+
+  if (notificationType === "court-assignment") {
+    const { data: entry } = await supabase
+      .from("queue_entries")
+      .select("status")
+      .eq("event_id", eventId)
+      .eq("user_id", userId)
+      .maybeSingle();
+
+    if (entry?.status !== "playing") {
+      return {
+        success: false,
+        error:
+          "Player is not on a court (status must be playing) to resend court assignment",
+      };
+    }
+
+    const courtNumber = await findActiveCourtNumber(
+      supabase,
+      eventId,
+      userId,
+    );
+    if (courtNumber == null) {
+      return {
+        success: false,
+        error: "No active court assignment found for this player",
+      };
+    }
+
+    const { data: qe } = await supabase
+      .from("queue_entries")
+      .select("position")
+      .eq("event_id", eventId)
+      .eq("user_id", userId)
+      .single();
+
+    const position = qe?.position ?? 1;
+    return sendQueueNotification(
+      userId,
+      eventId,
+      position,
+      "court-assignment",
+      courtNumber,
+    );
+  }
+
+  const { data: waiting } = await supabase
+    .from("queue_entries")
+    .select("position")
+    .eq("event_id", eventId)
+    .eq("user_id", userId)
+    .eq("status", "waiting")
+    .maybeSingle();
+
+  if (!waiting) {
+    return {
+      success: false,
+      error:
+        "Player is not in the waiting queue; resend is only available with current queue state",
+    };
+  }
+
+  return sendQueueNotification(
+    userId,
+    eventId,
+    waiting.position,
+    notificationType,
+  );
 }

--- a/app/actions/queue.ts
+++ b/app/actions/queue.ts
@@ -2,7 +2,10 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
-import { sendQueueNotification } from "./notifications";
+import {
+  flushQueueEmailNotifications,
+  sendQueueNotification,
+} from "./notifications";
 import type { Database } from "@/supabase/supa-schema";
 import type { GroupSize } from "@/lib/types";
 
@@ -154,9 +157,12 @@ export async function reorderQueue(eventId: string) {
     .order("position");
 
   if (queue) {
-    // Track notifications to avoid spamming
-    const upNextNotifications: Promise<unknown>[] = [];
-    const positionUpdateNotifications: Promise<unknown>[] = [];
+    const toNotify: Array<{
+      userId: string;
+      eventId: string;
+      position: number;
+      notificationType: "up-next" | "position-update";
+    }> = [];
 
     // Update positions
     for (let i = 0; i < queue.length; i++) {
@@ -170,31 +176,26 @@ export async function reorderQueue(eventId: string) {
 
       // Send "up next" email if they just entered top 4
       if (newPosition <= 4 && oldPosition > 4) {
-        upNextNotifications.push(
-          sendQueueNotification(
-            queue[i].user_id,
-            eventId,
-            newPosition,
-            "up-next",
-          ),
-        );
+        toNotify.push({
+          userId: queue[i].user_id,
+          eventId,
+          position: newPosition,
+          notificationType: "up-next",
+        });
       }
       // Send position update if they moved up significantly (3+ positions)
       else if (oldPosition - newPosition >= 3) {
-        positionUpdateNotifications.push(
-          sendQueueNotification(
-            queue[i].user_id,
-            eventId,
-            newPosition,
-            "position-update",
-          ),
-        );
+        toNotify.push({
+          userId: queue[i].user_id,
+          eventId,
+          position: newPosition,
+          notificationType: "position-update",
+        });
       }
     }
 
-    // Send notifications without blocking
-    Promise.all([...upNextNotifications, ...positionUpdateNotifications]).catch(
-      (err) => console.error("Error sending position update emails:", err),
+    await flushQueueEmailNotifications(toNotify).catch((err) =>
+      console.error("Error sending queue notification emails:", err),
     );
   }
 }
@@ -406,18 +407,19 @@ export async function assignPlayersToNextCourt(eventId: string) {
     if (updateError) {
       console.error(`Failed to update player ${player.id}:`, updateError);
     }
-
-    // Send court assignment email notification
-    sendQueueNotification(
-      player.userId,
-      eventId,
-      player.position,
-      "court-assignment",
-      availableCourt,
-    ).catch((err) =>
-      console.error("Failed to send court assignment email:", err),
-    );
   }
+
+  await flushQueueEmailNotifications(
+    nextPlayers.map((player) => ({
+      userId: player.userId,
+      eventId,
+      position: player.position,
+      notificationType: "court-assignment" as const,
+      courtNumber: availableCourt,
+    })),
+  ).catch((err) =>
+    console.error("Failed to send court assignment emails:", err),
+  );
 
   // Reorder remaining waiting players to fill gaps in positions
   await reorderQueue(eventId);

--- a/app/admin/email-stats/page.tsx
+++ b/app/admin/email-stats/page.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { ArrowLeft, Mail, CheckCircle, XCircle, Loader2 } from "lucide-react";
+import {
+  Mail,
+  CheckCircle,
+  XCircle,
+  Loader2,
+  RefreshCw,
+  ExternalLink,
+} from "lucide-react";
 import {
   Card,
   CardContent,
@@ -13,43 +20,100 @@ import {
 import { Button } from "@/components/ui/button";
 import { Header } from "@/components/ui/header";
 import { Badge } from "@/components/ui/badge";
-import { getEmailStats } from "@/app/actions/notifications";
+import {
+  getEmailStats,
+  resendQueueEmailFromLog,
+  type EmailLogRow,
+  type GetEmailStatsResult,
+} from "@/app/actions/notifications";
+import { toast } from "sonner";
+
+type EmailStatsResult = Extract<GetEmailStatsResult, { total: number }>;
+
+const initialStats: EmailStatsResult = {
+  total: 0,
+  successful: 0,
+  failed: 0,
+  failedOther: 0,
+  byType: {},
+  logs: [],
+  failedDeliveryLogs: [],
+};
 
 export default function EmailStatsPage() {
-  const [stats, setStats] = useState<any>(null);
+  const [stats, setStats] = useState<EmailStatsResult>(initialStats);
   const [timeRange, setTimeRange] = useState<
     "today" | "week" | "month" | "all"
   >("week");
   const [loading, setLoading] = useState(true);
+  const [resendingId, setResendingId] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchStats();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchStats is stable, timeRange triggers refetch
-  }, [timeRange]);
-
-  const emptyStats = {
-    total: 0,
-    successful: 0,
-    failed: 0,
-    byType: {} as Record<string, number>,
-    logs: [] as any[],
-  };
-
-  const fetchStats = async () => {
+  const fetchStats = useCallback(async () => {
+    const empty: EmailStatsResult = {
+      total: 0,
+      successful: 0,
+      failed: 0,
+      failedOther: 0,
+      byType: {},
+      logs: [],
+      failedDeliveryLogs: [],
+    };
     setLoading(true);
     try {
       const result = await getEmailStats(timeRange);
-      if (!result.error) {
-        setStats(result);
+      if ("error" in result) {
+        setStats(empty);
+        toast.error(result.error);
       } else {
-        setStats(emptyStats);
+        setStats(result);
       }
     } catch {
-      setStats(emptyStats);
+      setStats(empty);
     } finally {
       setLoading(false);
     }
+  }, [timeRange]);
+
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  const handleResend = async (log: EmailLogRow) => {
+    setResendingId(log.id);
+    try {
+      const result = await resendQueueEmailFromLog(log.id);
+      if (result.success) {
+        toast.success("Email sent again");
+        await fetchStats();
+      } else {
+        toast.error(
+          typeof result.error === "string"
+            ? result.error
+            : "Could not resend email",
+        );
+      }
+    } catch {
+      toast.error("Could not resend email");
+    } finally {
+      setResendingId(null);
+    }
   };
+
+  function formatLogTime(iso: string) {
+    try {
+      return new Date(iso).toLocaleString(undefined, {
+        dateStyle: "short",
+        timeStyle: "short",
+      });
+    } catch {
+      return iso;
+    }
+  }
+
+  function truncateError(msg: string | null, max = 96) {
+    if (!msg) return "—";
+    return msg.length <= max ? msg : `${msg.slice(0, max)}…`;
+  }
 
   if (loading) {
     return (
@@ -127,7 +191,7 @@ export default function EmailStatsPage() {
                     Total Emails
                   </p>
                   <p className="text-3xl font-bold text-foreground">
-                    {stats?.total || 0}
+                    {stats.total || 0}
                   </p>
                 </div>
                 <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center">
@@ -145,7 +209,7 @@ export default function EmailStatsPage() {
                     Successful
                   </p>
                   <p className="text-3xl font-bold text-green-600">
-                    {stats?.successful || 0}
+                    {stats.successful || 0}
                   </p>
                 </div>
                 <div className="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center">
@@ -159,10 +223,19 @@ export default function EmailStatsPage() {
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm text-muted-foreground mb-1">Failed</p>
-                  <p className="text-3xl font-bold text-red-600">
-                    {stats?.failed || 0}
+                  <p className="text-sm text-muted-foreground mb-1">
+                    Failed (delivery)
                   </p>
+                  <p className="text-3xl font-bold text-red-600">
+                    {stats.failed || 0}
+                  </p>
+                  {(stats.failedOther ?? 0) > 0 && (
+                    <p className="text-xs text-muted-foreground mt-1 max-w-[14rem]">
+                      {stats.failedOther} other failure
+                      {stats.failedOther === 1 ? "" : "s"} (missing email, bad
+                      data) hidden below
+                    </p>
+                  )}
                 </div>
                 <div className="w-12 h-12 bg-red-100 rounded-lg flex items-center justify-center">
                   <XCircle className="w-6 h-6 text-red-600" />
@@ -182,7 +255,7 @@ export default function EmailStatsPage() {
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
-              {Object.entries(stats?.byType || {}).map(([type, count]) => (
+              {Object.entries(stats.byType || {}).map(([type, count]) => (
                 <div
                   key={type}
                   className="flex items-center justify-between p-4 bg-muted/30 rounded-lg"
@@ -199,12 +272,115 @@ export default function EmailStatsPage() {
                   <span className="text-lg font-bold">{count as number}</span>
                 </div>
               ))}
-              {Object.keys(stats?.byType || {}).length === 0 && (
+              {Object.keys(stats.byType || {}).length === 0 && (
                 <p className="text-center text-muted-foreground py-8">
                   No emails sent yet
                 </p>
               )}
             </div>
+          </CardContent>
+        </Card>
+
+        {/* Failed sends — retry when queue/court state still matches */}
+        <Card className="border-border bg-card mb-8">
+          <CardHeader>
+            <CardTitle>Failed sends</CardTitle>
+            <CardDescription>
+              Resend send failures after automatic retries (network, TLS, rate
+              limits, etc.). Rows where we never attempted delivery—missing
+              account email, missing event, invalid data—are excluded. Resend
+              uses the player&apos;s current queue position or active court when
+              you resend.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {(() => {
+              const failed = stats.failedDeliveryLogs ?? [];
+              if (failed.length === 0) {
+                return (
+                  <p className="text-center text-muted-foreground py-6">
+                    No delivery failures in this range
+                  </p>
+                );
+              }
+              return (
+                <div className="overflow-x-auto rounded-lg border border-border">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-border bg-muted/40 text-left">
+                        <th className="p-3 font-medium">When</th>
+                        <th className="p-3 font-medium">Type</th>
+                        <th className="p-3 font-medium">Player</th>
+                        <th className="p-3 font-medium">Event</th>
+                        <th className="p-3 font-medium">Error</th>
+                        <th className="p-3 font-medium w-[120px]">Action</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {failed.map((log) => (
+                        <tr
+                          key={log.id}
+                          className="border-b border-border last:border-0"
+                        >
+                          <td className="p-3 whitespace-nowrap text-muted-foreground">
+                            {formatLogTime(log.sent_at)}
+                          </td>
+                          <td className="p-3">
+                            <Badge variant="outline">
+                              {log.notification_type}
+                            </Badge>
+                          </td>
+                          <td className="p-3">
+                            <div className="font-medium text-foreground">
+                              {log.user?.name ?? "—"}
+                            </div>
+                            <div className="text-muted-foreground text-xs truncate max-w-[200px]">
+                              {log.user?.email ?? "—"}
+                            </div>
+                          </td>
+                          <td className="p-3">
+                            {log.event_id ? (
+                              <Link
+                                href={`/admin/events/${log.event_id}`}
+                                className="inline-flex items-center gap-1 text-primary hover:underline"
+                              >
+                                {log.event?.name ?? "Event"}
+                                <ExternalLink className="w-3 h-3 shrink-0" />
+                              </Link>
+                            ) : (
+                              "—"
+                            )}
+                          </td>
+                          <td
+                            className="p-3 text-muted-foreground max-w-[280px]"
+                            title={log.error_message ?? undefined}
+                          >
+                            {truncateError(log.error_message)}
+                          </td>
+                          <td className="p-3">
+                            <Button
+                              type="button"
+                              variant="secondary"
+                              size="sm"
+                              disabled={resendingId === log.id}
+                              onClick={() => handleResend(log)}
+                              className="gap-1.5"
+                            >
+                              {resendingId === log.id ? (
+                                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                              ) : (
+                                <RefreshCw className="w-3.5 h-3.5" />
+                              )}
+                              Resend
+                            </Button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              );
+            })()}
           </CardContent>
         </Card>
 
@@ -228,7 +404,7 @@ export default function EmailStatsPage() {
                     Low Estimate ($0.0075/SMS)
                   </p>
                   <p className="text-2xl font-bold text-foreground">
-                    ${((stats?.total || 0) * 0.0075).toFixed(2)}
+                    ${((stats.total || 0) * 0.0075).toFixed(2)}
                   </p>
                 </div>
                 <div className="p-4 bg-muted/30 rounded-lg">
@@ -236,31 +412,31 @@ export default function EmailStatsPage() {
                     High Estimate ($0.02/SMS)
                   </p>
                   <p className="text-2xl font-bold text-foreground">
-                    ${((stats?.total || 0) * 0.02).toFixed(2)}
+                    ${((stats.total || 0) * 0.02).toFixed(2)}
                   </p>
                 </div>
               </div>
-              {timeRange === "week" && stats?.total > 0 && (
+              {timeRange === "week" && stats.total > 0 && (
                 <p className="text-sm text-muted-foreground mt-4">
                   Estimated monthly cost:{" "}
                   <strong>
-                    ${((stats?.total || 0) * 4 * 0.0075).toFixed(2)}
+                    ${((stats.total || 0) * 4 * 0.0075).toFixed(2)}
                   </strong>{" "}
                   -{" "}
                   <strong>
-                    ${((stats?.total || 0) * 4 * 0.02).toFixed(2)}
+                    ${((stats.total || 0) * 4 * 0.02).toFixed(2)}
                   </strong>
                 </p>
               )}
-              {timeRange === "today" && stats?.total > 0 && (
+              {timeRange === "today" && stats.total > 0 && (
                 <p className="text-sm text-muted-foreground mt-4">
                   If this daily rate continues, estimated monthly cost:{" "}
                   <strong>
-                    ${((stats?.total || 0) * 30 * 0.0075).toFixed(2)}
+                    ${((stats.total || 0) * 30 * 0.0075).toFixed(2)}
                   </strong>{" "}
                   -{" "}
                   <strong>
-                    ${((stats?.total || 0) * 30 * 0.02).toFixed(2)}
+                    ${((stats.total || 0) * 30 * 0.02).toFixed(2)}
                   </strong>
                 </p>
               )}

--- a/lib/email/email-delivery-log.ts
+++ b/lib/email/email-delivery-log.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure helpers for interpreting `email_logs` rows (not a Server Actions file).
+ */
+
+export function isActionableDeliveryFailure(log: {
+  success: boolean;
+  error_message: string | null;
+}): boolean {
+  if (log.success) return false;
+  const msg = (log.error_message ?? "").trim();
+  const notDelivery = [
+    "User email not found",
+    "Event not found",
+    "Court number is required",
+    "Invalid notification type",
+  ];
+  if (notDelivery.some((s) => msg === s || msg.startsWith(s))) return false;
+  return true;
+}

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -2,6 +2,103 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
+const RESEND_MAX_ATTEMPTS = 4;
+const RESEND_RETRY_BASE_MS = 400;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function errorFingerprint(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name} ${error.message}`;
+  }
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    const o = error as Record<string, unknown>;
+    const parts = [
+      typeof o.message === "string" ? o.message : "",
+      typeof o.name === "string" ? o.name : "",
+      typeof o.statusCode === "number" ? String(o.statusCode) : "",
+      typeof o.status === "number" ? String(o.status) : "",
+    ];
+    return parts.filter(Boolean).join(" ");
+  }
+  return String(error);
+}
+
+/** Network / rate-limit / upstream issues — safe to retry the same API call. */
+function isTransientSendError(error: unknown): boolean {
+  const msg = errorFingerprint(error).toLowerCase();
+  if (
+    [
+      "greeting never received",
+      "socket disconnected",
+      "tls",
+      "econnreset",
+      "etimedout",
+      "timeout",
+      "econnrefused",
+      "socket hang up",
+      "fetch failed",
+      "network error",
+      "429",
+      "too many requests",
+      "rate limit",
+      "status code 503",
+      "status code 502",
+      "status code 500",
+      "http 503",
+      "http 502",
+      "http 500",
+      "bad gateway",
+      "service unavailable",
+      "try again",
+    ].some((p) => msg.includes(p))
+  ) {
+    return true;
+  }
+  if (error && typeof error === "object") {
+    const s =
+      (error as { statusCode?: number }).statusCode ??
+      (error as { status?: number }).status;
+    if (s === 429 || s === 500 || s === 502 || s === 503) return true;
+  }
+  return false;
+}
+
+type ResendEmailPayload = Parameters<typeof resend.emails.send>[0];
+
+async function sendResendEmailWithRetry(
+  payload: ResendEmailPayload,
+): Promise<
+  { success: true; messageId?: string } | { success: false; error: unknown }
+> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < RESEND_MAX_ATTEMPTS; attempt++) {
+    try {
+      const { data: result, error } = await resend.emails.send(payload);
+      if (error) {
+        lastError = error;
+        if (isTransientSendError(error) && attempt < RESEND_MAX_ATTEMPTS - 1) {
+          await sleep(RESEND_RETRY_BASE_MS * 3 ** attempt);
+          continue;
+        }
+        return { success: false, error };
+      }
+      return { success: true, messageId: result?.id };
+    } catch (e) {
+      lastError = e;
+      if (isTransientSendError(e) && attempt < RESEND_MAX_ATTEMPTS - 1) {
+        await sleep(RESEND_RETRY_BASE_MS * 3 ** attempt);
+        continue;
+      }
+      return { success: false, error: e };
+    }
+  }
+  return { success: false, error: lastError };
+}
+
 // Resend requires verified domains or onboarding@resend.dev - Gmail/EMAIL_FROM won't work
 const RESEND_DEFAULT_FROM = "Ghost Mammoth Pickleball <onboarding@resend.dev>";
 
@@ -26,7 +123,7 @@ export interface QueueEmailData {
 
 export async function sendQueueJoinEmail(data: QueueEmailData) {
   try {
-    const { data: result, error } = await resend.emails.send({
+    const out = await sendResendEmailWithRetry({
       from: getFromEmail(),
       to: data.userEmail,
       subject: `Queue Confirmation - ${data.eventName}`,
@@ -72,11 +169,11 @@ export async function sendQueueJoinEmail(data: QueueEmailData) {
       text: `Hi ${data.userName},\n\nYou've successfully joined the queue for ${data.eventName}!\n\nEvent: ${data.eventName}\nLocation: ${data.eventLocation}\nDate: ${data.eventDate}\n${data.sentAt ? `Sent at: ${data.sentAt}\n` : ""}Your Position: #${data.currentPosition}\n${data.estimatedWaitTime ? `Estimated Wait: ~${data.estimatedWaitTime} minutes\n` : ""}\nWe'll notify you when you're up next!`,
     });
 
-    if (error) {
-      console.error("Error sending queue join email:", error);
-      return { success: false, error };
+    if (!out.success) {
+      console.error("Error sending queue join email:", out.error);
+      return out;
     }
-    return { success: true, messageId: result?.id };
+    return { success: true, messageId: out.messageId };
   } catch (error) {
     console.error("Error sending queue join email:", error);
     return { success: false, error };
@@ -85,7 +182,7 @@ export async function sendQueueJoinEmail(data: QueueEmailData) {
 
 export async function sendPositionUpdateEmail(data: QueueEmailData) {
   try {
-    const { data: result, error } = await resend.emails.send({
+    const out = await sendResendEmailWithRetry({
       from: getFromEmail(),
       to: data.userEmail,
       subject: `Queue Update - You've moved up!`,
@@ -127,11 +224,11 @@ export async function sendPositionUpdateEmail(data: QueueEmailData) {
       text: `Hi ${data.userName},\n\nYour position in the queue has been updated.\n\nEvent: ${data.eventName}\nCurrent Position: #${data.currentPosition}\n${data.estimatedWaitTime ? `Estimated Wait: ~${data.estimatedWaitTime} minutes\n` : ""}\nStay nearby - you'll be playing soon!`,
     });
 
-    if (error) {
-      console.error("Error sending position update email:", error);
-      return { success: false, error };
+    if (!out.success) {
+      console.error("Error sending position update email:", out.error);
+      return out;
     }
-    return { success: true, messageId: result?.id };
+    return { success: true, messageId: out.messageId };
   } catch (error) {
     console.error("Error sending position update email:", error);
     return { success: false, error };
@@ -140,7 +237,7 @@ export async function sendPositionUpdateEmail(data: QueueEmailData) {
 
 export async function sendUpNextEmail(data: QueueEmailData) {
   try {
-    const { data: result, error } = await resend.emails.send({
+    const out = await sendResendEmailWithRetry({
       from: getFromEmail(),
       to: data.userEmail,
       subject: `🎾 You're Up Next! - ${data.eventName}`,
@@ -186,11 +283,11 @@ export async function sendUpNextEmail(data: QueueEmailData) {
       text: `Hi ${data.userName},\n\n🎾 YOU'RE UP NEXT!\n\nGet ready! You're one of the next players to be assigned to a court.\n\nEvent: ${data.eventName}\nLocation: ${data.eventLocation}\nYour Position: #${data.currentPosition}\n\nPlease make sure you're at the venue and ready to play!`,
     });
 
-    if (error) {
-      console.error("Error sending up next email:", error);
-      return { success: false, error };
+    if (!out.success) {
+      console.error("Error sending up next email:", out.error);
+      return out;
     }
-    return { success: true, messageId: result?.id };
+    return { success: true, messageId: out.messageId };
   } catch (error) {
     console.error("Error sending up next email:", error);
     return { success: false, error };
@@ -203,7 +300,7 @@ export async function sendCourtAssignmentEmail(data: QueueEmailData) {
   }
 
   try {
-    const { data: result, error } = await resend.emails.send({
+    const out = await sendResendEmailWithRetry({
       from: getFromEmail(),
       to: data.userEmail,
       subject: `🎾 Time to Play! Court ${data.courtNumber} - ${data.eventName}`,
@@ -250,11 +347,11 @@ export async function sendCourtAssignmentEmail(data: QueueEmailData) {
       text: `Hi ${data.userName},\n\n🎾 IT'S YOUR TURN TO PLAY!\n\nYou've been assigned to Court #${data.courtNumber}\n\nEvent: ${data.eventName}\nLocation: ${data.eventLocation}\n\nPlease head to Court #${data.courtNumber} now!\n\nHave a great game! 🏓`,
     });
 
-    if (error) {
-      console.error("Error sending court assignment email:", error);
-      return { success: false, error };
+    if (!out.success) {
+      console.error("Error sending court assignment email:", out.error);
+      return out;
     }
-    return { success: true, messageId: result?.id };
+    return { success: true, messageId: out.messageId };
   } catch (error) {
     console.error("Error sending court assignment email:", error);
     return { success: false, error };

--- a/lib/run-with-concurrency.ts
+++ b/lib/run-with-concurrency.ts
@@ -1,0 +1,23 @@
+/**
+ * Run async tasks with at most `concurrency` in flight (order of completion may vary).
+ */
+export async function runWithConcurrency<T>(
+  tasks: Array<() => Promise<T>>,
+  concurrency: number,
+): Promise<T[]> {
+  if (tasks.length === 0) return [];
+  const limit = Math.max(1, Math.min(concurrency, tasks.length));
+  const results: T[] = new Array(tasks.length);
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const i = next++;
+      if (i >= tasks.length) return;
+      results[i] = await tasks[i]!();
+    }
+  }
+
+  await Promise.all(Array.from({ length: limit }, () => worker()));
+  return results;
+}


### PR DESCRIPTION
- Retry Resend API calls with backoff on transient network/rate errors
- Send queue emails with bounded concurrency and await batches in queue actions
- Admin email stats: count/list only actionable delivery failures; show other failures count
- Move isActionableDeliveryFailure to lib (Server Actions cannot export sync fns)
- Update email-notifications operator doc