### PR TITLE
feat(auth): forgot password, reset password, and a11y test stability

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -60,14 +60,24 @@ export async function GET(request: Request) {
   if (user) {
     const supabaseAdmin = createServiceRoleClient();
     if (supabaseAdmin) {
+      const { data: existing } = await supabaseAdmin
+        .from("users")
+        .select("is_admin")
+        .eq("id", user.id)
+        .maybeSingle();
+
       await supabaseAdmin.from("users").upsert(
         {
           id: user.id,
           email: user.email ?? "",
-          name: (user.user_metadata?.name as string) ?? user.email?.split("@")[0] ?? "User",
-          skill_level: (user.user_metadata?.skill_level as string) ?? "intermediate",
+          name:
+            (user.user_metadata?.name as string) ??
+            user.email?.split("@")[0] ??
+            "User",
+          skill_level:
+            (user.user_metadata?.skill_level as string) ?? "intermediate",
           phone: (user.user_metadata?.phone as string) ?? "",
-          is_admin: false,
+          is_admin: existing?.is_admin ?? false,
         },
         { onConflict: "id" }
       );

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/lib/auth-context";
+import { Header } from "@/components/ui/header";
+
+function ForgotPasswordForm() {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+  const { resetPasswordForEmail } = useAuth();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const { error: resetError } = await resetPasswordForEmail(email.trim());
+    setLoading(false);
+
+    if (resetError) {
+      setError(resetError.message ?? "Something went wrong. Please try again.");
+      return;
+    }
+
+    setSent(true);
+  };
+
+  return (
+    <div className="flex items-center justify-center p-4 py-12">
+      <div className="w-full max-w-md">
+        <h1 className="sr-only">Reset password</h1>
+        <Card className="border-border bg-card">
+          <CardHeader>
+            <CardTitle className="text-foreground">Forgot password</CardTitle>
+            <CardDescription>
+              Enter your email and we&apos;ll send you a link to choose a new
+              password.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {sent ? (
+              <div className="space-y-4">
+                <div className="p-3 text-sm text-green-700 bg-green-50 dark:text-green-200 dark:bg-green-950 rounded-md">
+                  If an account exists for that address, you&apos;ll receive an
+                  email with a reset link shortly. Check your spam folder if you
+                  don&apos;t see it.
+                </div>
+                <Button variant="outline" className="w-full" asChild>
+                  <Link href="/login">Back to sign in</Link>
+                </Button>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                {error && (
+                  <div className="p-3 text-sm text-destructive-foreground bg-destructive rounded-md">
+                    {error}
+                  </div>
+                )}
+                <div className="space-y-2">
+                  <Label htmlFor="email">Email</Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="you@example.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    autoComplete="email"
+                  />
+                </div>
+                <Button type="submit" className="w-full" disabled={loading}>
+                  {loading ? "Sending..." : "Send reset link"}
+                </Button>
+                <div className="text-center text-sm text-muted-foreground">
+                  <Link href="/login" className="text-primary hover:underline">
+                    Back to sign in
+                  </Link>
+                </div>
+              </form>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <ForgotPasswordForm />
+    </div>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -186,7 +186,15 @@ function LoginForm() {
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="password">Password</Label>
+                <div className="flex items-center justify-between gap-2">
+                  <Label htmlFor="password">Password</Label>
+                  <Link
+                    href="/forgot-password"
+                    className="text-sm text-primary hover:underline"
+                  >
+                    Forgot password?
+                  </Link>
+                </div>
                 <div className="relative">
                   <Input
                     id="password"

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/lib/auth-context";
+import { Header } from "@/components/ui/header";
+
+function ResetPasswordForm() {
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const { user, loading: authLoading, updatePassword, signOut } = useAuth();
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters");
+      return;
+    }
+
+    setLoading(true);
+    const { error: updateError } = await updatePassword(password);
+    setLoading(false);
+
+    if (updateError) {
+      setError(updateError.message ?? "Could not update password.");
+      return;
+    }
+
+    await signOut();
+    router.replace(
+      "/login?message=" +
+        encodeURIComponent(
+          "Your password has been updated. Please sign in with your new password.",
+        ),
+    );
+  };
+
+  if (authLoading) {
+    return (
+      <div className="flex items-center justify-center p-4 py-12">
+        <h1 className="sr-only">Set new password</h1>
+        <div className="text-muted-foreground">Loading...</div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="flex items-center justify-center p-4 py-12">
+        <div className="w-full max-w-md">
+          <h1 className="sr-only">Set new password</h1>
+          <Card className="border-border bg-card">
+            <CardHeader>
+              <CardTitle className="text-foreground">Link required</CardTitle>
+              <CardDescription>
+                Open the reset link from your email, or request a new one below.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3">
+              <Button asChild>
+                <Link href="/forgot-password">Request reset link</Link>
+              </Button>
+              <Button variant="outline" asChild>
+                <Link href="/login">Back to sign in</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center p-4 py-12">
+      <div className="w-full max-w-md">
+        <h1 className="sr-only">Set new password</h1>
+        <Card className="border-border bg-card">
+          <CardHeader>
+            <CardTitle className="text-foreground">Set new password</CardTitle>
+            <CardDescription>
+              Choose a new password for your account.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {error && (
+                <div className="p-3 text-sm text-destructive-foreground bg-destructive rounded-md">
+                  {error}
+                </div>
+              )}
+              <div className="space-y-2">
+                <Label htmlFor="new-password">New password</Label>
+                <div className="relative">
+                  <Input
+                    id="new-password"
+                    type={showPassword ? "text" : "password"}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                    minLength={6}
+                    autoComplete="new-password"
+                    className="pr-10"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                    onClick={() => setShowPassword(!showPassword)}
+                    aria-label={
+                      showPassword ? "Hide password" : "Show password"
+                    }
+                  >
+                    {showPassword ? (
+                      <EyeOff
+                        className="h-4 w-4 text-muted-foreground"
+                        aria-hidden
+                      />
+                    ) : (
+                      <Eye
+                        className="h-4 w-4 text-muted-foreground"
+                        aria-hidden
+                      />
+                    )}
+                  </Button>
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="confirm-password">Confirm new password</Label>
+                <div className="relative">
+                  <Input
+                    id="confirm-password"
+                    type={showConfirmPassword ? "text" : "password"}
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    required
+                    minLength={6}
+                    autoComplete="new-password"
+                    className="pr-10"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    aria-label={
+                      showConfirmPassword ? "Hide password" : "Show password"
+                    }
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff
+                        className="h-4 w-4 text-muted-foreground"
+                        aria-hidden
+                      />
+                    ) : (
+                      <Eye
+                        className="h-4 w-4 text-muted-foreground"
+                        aria-hidden
+                      />
+                    )}
+                  </Button>
+                </div>
+              </div>
+              <Button type="submit" className="w-full" disabled={loading}>
+                {loading ? "Updating..." : "Update password"}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <ResetPasswordForm />
+    </div>
+  );
+}

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -9,12 +9,15 @@ import AxeBuilder from "@axe-core/playwright";
  * are still recommended for compliance and lawsuit risk mitigation.
  */
 
-test.setTimeout(60_000);
+// Slow first compile + middleware (Supabase session) can exceed 60s on cold starts.
+test.setTimeout(120_000);
 
 const routesToCheck = [
   // Public
   { path: "/", name: "Home" },
   { path: "/login", name: "Login" },
+  { path: "/forgot-password", name: "Forgot password" },
+  { path: "/reset-password", name: "Reset password" },
   { path: "/signup", name: "Signup" },
   { path: "/events", name: "Events" },
   { path: "/about", name: "About" },
@@ -59,13 +62,16 @@ async function gotoAndWaitForReady(
   const msg = (e: Error) => String(e.message);
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
+      // `commit` can fire before the streamed layout (with #main-content) is in the DOM.
+      // `load` waits for the document; we then wait for `attached` (not `visible`) because
+      // an empty <main> can have zero height until children paint, which fails Playwright visibility.
       await page.goto(path, {
-        waitUntil: "commit",
-        timeout: 20_000,
+        waitUntil: "load",
+        timeout: 60_000,
       });
       await page.waitForSelector("#main-content", {
-        state: "visible",
-        timeout: 20_000,
+        state: "attached",
+        timeout: 30_000,
       });
       return;
     } catch (e) {
@@ -73,9 +79,8 @@ async function gotoAndWaitForReady(
       const aborted =
         msg(err).includes("ERR_ABORTED") || msg(err).includes("frame was detached");
       if (aborted) {
-        const main = await page.locator("#main-content").first();
-        const visible = await main.isVisible().catch(() => false);
-        if (visible) return;
+        const count = await page.locator("#main-content").count();
+        if (count > 0) return;
       }
       if (attempt < maxAttempts) {
         await new Promise((r) => setTimeout(r, 1_500));

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -16,6 +16,8 @@ interface AuthContextType {
   ) => Promise<{ error: any }>;
   signOut: () => Promise<void>;
   resendVerificationEmail: (email: string) => Promise<{ error: any }>;
+  resetPasswordForEmail: (email: string) => Promise<{ error: any }>;
+  updatePassword: (newPassword: string) => Promise<{ error: any }>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -177,6 +179,35 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return { error };
   };
 
+  const resetPasswordForEmail = async (email: string) => {
+    const baseUrl =
+      process.env.NEXT_PUBLIC_URL ||
+      (typeof window !== "undefined" ? window.location.origin : null);
+
+    if (!baseUrl) {
+      return {
+        error: new Error(
+          "Configuration error: Unable to determine application URL"
+        ),
+      };
+    }
+
+    const base = baseUrl.replace(/\/$/, "");
+    const redirectTo = `${base}/auth/callback?next=${encodeURIComponent("/reset-password")}`;
+
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo,
+    });
+    return { error };
+  };
+
+  const updatePassword = async (newPassword: string) => {
+    const { error } = await supabase.auth.updateUser({
+      password: newPassword,
+    });
+    return { error };
+  };
+
   const value = {
     user,
     session,
@@ -185,6 +216,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     signUp,
     signOut,
     resendVerificationEmail,
+    resetPasswordForEmail,
+    updatePassword,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -41,6 +41,8 @@ export async function updateSession(request: NextRequest) {
   const isPublicPath =
     request.nextUrl.pathname.startsWith("/login") ||
     request.nextUrl.pathname.startsWith("/signup") ||
+    request.nextUrl.pathname.startsWith("/forgot-password") ||
+    request.nextUrl.pathname.startsWith("/reset-password") ||
     request.nextUrl.pathname.startsWith("/about") ||
     request.nextUrl.pathname.startsWith("/auth/callback") ||
     request.nextUrl.pathname === "/" ||


### PR DESCRIPTION
- Add /forgot-password and /reset-password; wire resetPasswordForEmail and updatePassword in auth context; link from login
- Allow public access to forgot/reset routes in middleware
- Preserve is_admin on auth callback profile upsert
- A11y e2e: wait for load + #main-content attached; extend timeouts for cold dev