### PR TITLE
Q tshoot

### DIFF
--- a/app/actions/notifications.ts
+++ b/app/actions/notifications.ts
@@ -481,7 +481,7 @@ export async function resendQueueEmailFromLog(logId: string) {
     .select("position")
     .eq("event_id", eventId)
     .eq("user_id", userId)
-    .eq("status", "waiting")
+    .in("status", ["waiting", "pending_solo"])
     .maybeSingle();
 
   if (!waiting) {

--- a/app/actions/queue.ts
+++ b/app/actions/queue.ts
@@ -53,6 +53,138 @@ function isRotateAllStyleRotation(rt: RotationType): boolean {
   return rt === "rotate-all";
 }
 
+/** Subsets of group indices whose sizes sum to `target` (same semantics as QueueManager). */
+function collectExactCombinationIndices(
+  groupSizes: number[],
+  target: number,
+  startIdx: number,
+  current: number[],
+  currentSum: number,
+  out: number[][],
+): void {
+  if (currentSum === target) {
+    out.push([...current]);
+    return;
+  }
+  if (currentSum > target || startIdx >= groupSizes.length) {
+    return;
+  }
+  collectExactCombinationIndices(
+    groupSizes,
+    target,
+    startIdx + 1,
+    [...current, startIdx],
+    currentSum + groupSizes[startIdx],
+    out,
+  );
+  collectExactCombinationIndices(
+    groupSizes,
+    target,
+    startIdx + 1,
+    current,
+    currentSum,
+    out,
+  );
+}
+
+function soloGroupIndexCanFillCourt(
+  groupSizes: number[],
+  soloGroupIdx: number,
+  playersPerCourt: number,
+): boolean {
+  const solutions: number[][] = [];
+  collectExactCombinationIndices(
+    groupSizes,
+    playersPerCourt,
+    0,
+    [],
+    0,
+    solutions,
+  );
+  return solutions.some((sol) => sol.includes(soloGroupIdx));
+}
+
+/**
+ * Promotes pending solos when 2+ solos exist; demotes a lone waiting solo when
+ * no full-court combination can include them (e.g. one solo + only duos for doubles).
+ * TODO: optional email when status flips waiting <-> pending_solo
+ */
+export async function reconcilePendingSoloForEvent(eventId: string) {
+  const supabase = await createClient();
+
+  const { data: eventRow } = await supabase
+    .from("events")
+    .select("team_size")
+    .eq("id", eventId)
+    .single();
+
+  const teamSize = (eventRow?.team_size || 2) as TeamSize;
+  const playersPerCourt = teamSize * 2;
+
+  const { data: soloRows } = await supabase
+    .from("queue_entries")
+    .select("id")
+    .eq("event_id", eventId)
+    .in("status", ["waiting", "pending_solo"])
+    .eq("group_size", 1);
+
+  const soloCount = soloRows?.length ?? 0;
+  if (soloCount >= 2) {
+    await supabase
+      .from("queue_entries")
+      .update({ status: "waiting" })
+      .eq("event_id", eventId)
+      .eq("status", "pending_solo")
+      .eq("group_size", 1);
+  }
+
+  const { data: waitingRows } = await supabase
+    .from("queue_entries")
+    .select("id, group_size, group_id, position")
+    .eq("event_id", eventId)
+    .eq("status", "waiting")
+    .order("position");
+
+  if (!waitingRows?.length) {
+    return;
+  }
+
+  const groups: { ids: string[]; size: number }[] = [];
+  const processedGroupIds = new Set<string>();
+
+  for (const row of waitingRows) {
+    const gid = row.group_id;
+    if (gid && !processedGroupIds.has(gid)) {
+      const members = waitingRows.filter((r) => r.group_id === gid);
+      processedGroupIds.add(gid);
+      const size = members.reduce((s, m) => s + (m.group_size || 1), 0);
+      groups.push({ ids: members.map((m) => m.id), size });
+    } else if (!gid) {
+      groups.push({ ids: [row.id], size: row.group_size || 1 });
+    }
+  }
+
+  const soloGroups = groups
+    .map((g, idx) => ({ g, idx }))
+    .filter(({ g }) => g.size === 1);
+  if (soloGroups.length !== 1) {
+    return;
+  }
+
+  const soloGroupIdx = soloGroups[0].idx;
+  const groupSizes = groups.map((g) => g.size);
+
+  if (soloGroupIndexCanFillCourt(groupSizes, soloGroupIdx, playersPerCourt)) {
+    return;
+  }
+
+  const soloEntryId = soloGroups[0].g.ids[0];
+  await supabase
+    .from("queue_entries")
+    .update({ status: "pending_solo" })
+    .eq("id", soloEntryId);
+}
+
 function entryIdForGameUser(
   gameQueueEntryIds: string[],
   userId: string,
@@ -125,7 +257,7 @@ export async function getQueue(eventId: string) {
     `,
     )
     .eq("event_id", eventId)
-    .eq("status", "waiting")
+    .in("status", ["waiting", "pending_solo"])
     .order("position");
 
   if (error) {
@@ -157,13 +289,25 @@ export async function joinQueue(
     .from("queue_entries")
     .select("position")
     .eq("event_id", eventId)
-    .eq("status", "waiting")
+    .in("status", ["waiting", "pending_solo"])
     .order("position", { ascending: false })
     .limit(1);
 
   const position = currentQueue?.[0]?.position
     ? currentQueue[0].position + 1
     : 1;
+
+  let insertStatus: "waiting" | "pending_solo" = "waiting";
+  if (groupSize === 1) {
+    const { count: existingSoloCount } = await supabase
+      .from("queue_entries")
+      .select("*", { count: "exact", head: true })
+      .eq("event_id", eventId)
+      .in("status", ["waiting", "pending_solo"])
+      .eq("group_size", 1);
+    const n = existingSoloCount ?? 0;
+    insertStatus = n >= 1 ? "waiting" : "pending_solo";
+  }
 
   const { data, error } = await supabase
     .from("queue_entries")
@@ -174,7 +318,7 @@ export async function joinQueue(
       group_size: groupSize,
       player_names: playerNames || [],
       position: position,
-      status: "waiting",
+      status: insertStatus,
     })
     .select()
     .single();
@@ -183,6 +327,18 @@ export async function joinQueue(
     console.error("Error joining queue:", error);
     return { error: error.message };
   }
+
+  if (groupSize === 1 && insertStatus === "waiting") {
+    await supabase
+      .from("queue_entries")
+      .update({ status: "waiting" })
+      .eq("event_id", eventId)
+      .eq("status", "pending_solo")
+      .eq("group_size", 1);
+  }
+
+  await reconcilePendingSoloForEvent(eventId);
+  await reorderQueue(eventId);
 
   // Send email notification (async, don't await to avoid blocking)
   await sendQueueNotification(userId, eventId, position, "join").catch((err) =>
@@ -227,6 +383,8 @@ export async function leaveQueue(queueEntryId: string) {
 
   // Reorder remaining queue positions
   await reorderQueue(entry.event_id);
+  await reconcilePendingSoloForEvent(entry.event_id);
+  await reorderQueue(entry.event_id);
 
   revalidatePath(`/events/${entry.event_id}`);
   return { error: null };
@@ -239,7 +397,7 @@ export async function reorderQueue(eventId: string) {
     .from("queue_entries")
     .select("*")
     .eq("event_id", eventId)
-    .eq("status", "waiting")
+    .in("status", ["waiting", "pending_solo"])
     .order("position");
 
   if (queue) {
@@ -259,6 +417,10 @@ export async function reorderQueue(eventId: string) {
         .from("queue_entries")
         .update({ position: newPosition })
         .eq("id", queue[i].id);
+
+      if (queue[i].status !== "waiting") {
+        continue;
+      }
 
       // Send "up next" email if they just entered top 4
       if (newPosition <= 4 && oldPosition > 4) {
@@ -528,6 +690,7 @@ export async function endGameAndReorderQueue(
     }
   }
 
+  await reconcilePendingSoloForEvent(eventId);
   await reorderQueue(eventId);
 
   revalidatePath(`/events/${eventId}`);
@@ -557,7 +720,12 @@ function mapDbEntryToManagerEntry(entry: QueueEntryWithUser) {
     groupSize: (entry.group_size || 1) as GroupSize,
     player_names: playerNamesArray,
     position: entry.position,
-    status: entry.status as "waiting" | "playing" | "completed" | "pending_stay",
+    status: entry.status as
+      | "waiting"
+      | "pending_solo"
+      | "playing"
+      | "completed"
+      | "pending_stay",
     joinedAt: new Date(entry.joined_at),
     user: entry.user
       ? {
@@ -836,6 +1004,7 @@ export async function assignPlayersToNextCourt(eventId: string) {
     console.error("Failed to send court assignment emails:", err),
   );
 
+  await reconcilePendingSoloForEvent(eventId);
   await reorderQueue(eventId);
 
   revalidatePath(`/events/${eventId}`);
@@ -915,6 +1084,8 @@ export async function adminRemoveFromQueue(queueEntryId: string) {
     }
   }
 
+  await reorderQueue(entry.event_id);
+  await reconcilePendingSoloForEvent(entry.event_id);
   await reorderQueue(entry.event_id);
 
   revalidatePath(`/events/${entry.event_id}`);

--- a/app/actions/test-helpers.ts
+++ b/app/actions/test-helpers.ts
@@ -44,6 +44,17 @@ function leaderFriendLabel(leaderName: string, friendSlotIndex: number): string 
   return `${leaderShortName(leaderName)}'s friend ${suffix}`;
 }
 
+/** Match production queue rules after bulk test inserts (pending_solo, positions). */
+async function normalizeQueueAfterTestSeed(eventId: string) {
+  const { reconcilePendingSoloForEvent, reorderQueue } = await import(
+    "./queue"
+  );
+  await reconcilePendingSoloForEvent(eventId);
+  await reorderQueue(eventId);
+  revalidatePath(`/events/${eventId}`);
+  revalidatePath(`/admin/events/${eventId}`);
+}
+
 export async function resetTestEvent(eventId: string) {
   const supabase = await createClient();
 
@@ -141,7 +152,13 @@ export async function resetTestEvent(eventId: string) {
     }
   }
 
-  revalidatePath(`/admin/events/${eventId}`);
+  if (successCount > 0) {
+    await normalizeQueueAfterTestSeed(eventId);
+  } else {
+    revalidatePath(`/events/${eventId}`);
+    revalidatePath(`/admin/events/${eventId}`);
+  }
+
   return {
     success: successCount > 0,
     error: successCount === 0 ? "Failed to reset event" : null,
@@ -233,7 +250,13 @@ export async function addDummyUsersToQueue(
     }
   }
 
-  revalidatePath(`/admin/events/${eventId}`);
+  if (successCount > 0) {
+    await normalizeQueueAfterTestSeed(eventId);
+  } else {
+    revalidatePath(`/events/${eventId}`);
+    revalidatePath(`/admin/events/${eventId}`);
+  }
+
   return {
     success: successCount > 0,
     added: successCount,

--- a/app/actions/test-helpers.ts
+++ b/app/actions/test-helpers.ts
@@ -27,6 +27,23 @@ const TEST_USER_IDS = [
   "00000000-0000-0000-0000-000000000020",
 ];
 
+const FRIEND_SUFFIXES = ["A", "B", "C", "D", "E", "F", "G", "H"] as const;
+
+/** First token of display name for leader-scoped test labels, e.g. "Alex Smith" -> "Alex". */
+function leaderShortName(leaderName: string): string {
+  const trimmed = leaderName.trim();
+  if (!trimmed) return "Leader";
+  const first = trimmed.split(/\s+/)[0];
+  return first || "Leader";
+}
+
+/** e.g. "Alex's friend A", "Alex's friend B" — makes groups easy to spot in queue/court screenshots. */
+function leaderFriendLabel(leaderName: string, friendSlotIndex: number): string {
+  const suffix =
+    FRIEND_SUFFIXES[friendSlotIndex] ?? String(friendSlotIndex + 1);
+  return `${leaderShortName(leaderName)}'s friend ${suffix}`;
+}
+
 export async function resetTestEvent(eventId: string) {
   const supabase = await createClient();
 
@@ -73,21 +90,10 @@ export async function resetTestEvent(eventId: string) {
 
   const usersMap = new Map(usersData?.map((u) => [u.id, u]) || []);
 
-  // Names for additional group members
-  const friendNames = [
-    "Friend A",
-    "Friend B",
-    "Friend C",
-    "Friend D",
-    "Friend E",
-    "Friend F",
-    "Friend G",
-    "Friend H",
-  ];
   const skillLevels = ["beginner", "intermediate", "advanced", "pro"];
 
   let successCount = 0;
-  let friendIndex = 0;
+  let friendSkillIndex = 0;
 
   for (let i = 0; i < usersToAdd.length; i++) {
     const groupSize = groupSizes[i] || 1;
@@ -108,12 +114,11 @@ export async function resetTestEvent(eventId: string) {
           skillLevel: userData.skill_level || "intermediate",
         });
       } else {
-        // Additional players get unique friend names
         playerNames.push({
-          name: friendNames[friendIndex % friendNames.length],
-          skillLevel: skillLevels[(friendIndex + j) % skillLevels.length],
+          name: leaderFriendLabel(userData.name, j - 1),
+          skillLevel: skillLevels[(friendSkillIndex + j) % skillLevels.length],
         });
-        friendIndex++;
+        friendSkillIndex++;
       }
     }
 
@@ -180,17 +185,6 @@ export async function addDummyUsersToQueue(
 
   const usersMap = new Map(usersData?.map((u) => [u.id, u]) || []);
 
-  // Names for additional group members
-  const friendNames = [
-    "Friend A",
-    "Friend B",
-    "Friend C",
-    "Friend D",
-    "Friend E",
-    "Friend F",
-    "Friend G",
-    "Friend H",
-  ];
   const skillLevels = ["beginner", "intermediate", "advanced", "pro"];
 
   // Check for insert errors
@@ -213,9 +207,8 @@ export async function addDummyUsersToQueue(
           skillLevel: userData.skill_level || "intermediate",
         });
       } else {
-        // Additional players get unique friend names
         playerNames.push({
-          name: friendNames[(i + j - 1) % friendNames.length],
+          name: leaderFriendLabel(userData.name, j - 1),
           skillLevel: skillLevels[(i + j) % skillLevels.length],
         });
       }

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -658,6 +658,7 @@ export default function AdminEventDetailPage(props: {
               currentRotationType={event.rotationType}
               currentTeamSize={event.teamSize}
               currentCourtCount={event.courtCount}
+              onQueueUpdated={() => void fetchQueue()}
             />
           </div>
         )}

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -453,7 +453,9 @@ export default function AdminEventDetailPage(props: {
     };
   }, [id]);
 
-  const waitingCount = queue.filter((e) => e.status === "waiting").length;
+  const waitingCount = queue.filter(
+    (e) => e.status === "waiting" || e.status === "pending_solo",
+  ).length;
   const playingCount =
     assignments.filter((a) => !a.endedAt).length * (event?.teamSize || 2) * 2;
 
@@ -533,7 +535,7 @@ export default function AdminEventDetailPage(props: {
         .from("queue_entries")
         .delete()
         .eq("event_id", id)
-        .eq("status", "waiting");
+        .in("status", ["waiting", "pending_solo"]);
 
       if (error) {
         console.error("Error clearing queue:", error);

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, use } from "react";
+import { useState, useEffect, use, useCallback } from "react";
 import Link from "next/link";
 import {
   Trophy,
@@ -178,76 +178,73 @@ export default function AdminEventDetailPage(props: {
     fetchEvent();
   }, [id]);
 
-  // Fetch queue data
-  useEffect(() => {
-    const fetchQueue = async () => {
-      const supabase = createClient();
-      const { data, error } = await supabase
-        .from("queue_entries")
-        .select(
-          `
+  const fetchQueue = useCallback(async () => {
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from("queue_entries")
+      .select(
+        `
           *,
           user:users(id, name, email, skill_level)
         `,
-        )
-        .eq("event_id", id)
-        .order("position");
+      )
+      .eq("event_id", id)
+      .order("position");
 
-      if (error) {
-        console.error("Error fetching queue:", error);
-        return;
-      }
+    if (error) {
+      console.error("Error fetching queue:", error);
+      return;
+    }
 
-      if (data) {
-        const queueEntries: QueueEntry[] = data.map(
-          (entry: QueueEntryWithUser) => {
-            // Parse player_names JSON if it exists
-            let playerNamesArray: Array<{
-              name: string;
-              skillLevel: string;
-            }> = [];
-            if (entry.player_names) {
-              try {
-                const parsed = entry.player_names as unknown as Array<{
-                  name: string;
-                  skillLevel: string;
-                }>;
-                playerNamesArray = Array.isArray(parsed) ? parsed : [];
-              } catch {
-                playerNamesArray = [];
-              }
+    if (data) {
+      const queueEntries: QueueEntry[] = data.map(
+        (entry: QueueEntryWithUser) => {
+          let playerNamesArray: Array<{
+            name: string;
+            skillLevel: string;
+          }> = [];
+          if (entry.player_names) {
+            try {
+              const parsed = entry.player_names as unknown as Array<{
+                name: string;
+                skillLevel: string;
+              }>;
+              playerNamesArray = Array.isArray(parsed) ? parsed : [];
+            } catch {
+              playerNamesArray = [];
             }
+          }
 
-            return {
-              id: entry.id,
-              eventId: entry.event_id,
-              userId: entry.user_id,
-              groupSize: (entry.group_size || 1) as GroupSize,
-              groupId: entry.group_id || undefined,
-              player_names: playerNamesArray,
-              position: entry.position,
-              status: entry.status as QueueStatus,
-              joinedAt: new Date(entry.joined_at),
-              user: entry.user
-                ? {
-                    id: entry.user.id,
-                    name: entry.user.name,
-                    email: entry.user.email,
-                    skillLevel: entry.user.skill_level as SkillLevel,
-                    isAdmin: false,
-                    createdAt: new Date(),
-                  }
-                : undefined,
-            };
-          },
-        );
-        setQueue(queueEntries);
-      }
-    };
+          return {
+            id: entry.id,
+            eventId: entry.event_id,
+            userId: entry.user_id,
+            groupSize: (entry.group_size || 1) as GroupSize,
+            groupId: entry.group_id || undefined,
+            player_names: playerNamesArray,
+            position: entry.position,
+            status: entry.status as QueueStatus,
+            joinedAt: new Date(entry.joined_at),
+            user: entry.user
+              ? {
+                  id: entry.user.id,
+                  name: entry.user.name,
+                  email: entry.user.email,
+                  skillLevel: entry.user.skill_level as SkillLevel,
+                  isAdmin: false,
+                  createdAt: new Date(),
+                }
+              : undefined,
+          };
+        },
+      );
+      setQueue(queueEntries);
+    }
+  }, [id]);
 
-    fetchQueue();
+  useEffect(() => {
+    void fetchQueue();
 
-    // Set up real-time subscription
     const supabase = createClient();
     const channel = supabase
       .channel(`admin-queue-${id}`)
@@ -260,7 +257,7 @@ export default function AdminEventDetailPage(props: {
           filter: `event_id=eq.${id}`,
         },
         () => {
-          fetchQueue();
+          void fetchQueue();
         },
       )
       .subscribe();
@@ -268,7 +265,7 @@ export default function AdminEventDetailPage(props: {
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [id]);
+  }, [id, fetchQueue]);
 
   // Fetch court assignments
   useEffect(() => {
@@ -508,6 +505,7 @@ export default function AdminEventDetailPage(props: {
         });
       } else {
         toast.success("Player removed from queue");
+        await fetchQueue();
       }
     } catch (err) {
       console.error("❌ [ADMIN PAGE] Exception in handleForceRemove:", err);
@@ -544,6 +542,7 @@ export default function AdminEventDetailPage(props: {
         });
       } else {
         toast.success("Queue cleared successfully");
+        await fetchQueue();
       }
     } catch (err) {
       console.error("Error clearing queue:", err);

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, use, useCallback } from "react";
+import { useState, useEffect, use } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import {
   Trophy,
@@ -11,7 +12,6 @@ import {
   Calendar,
   Play,
   Trash2,
-  History,
   Loader2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -23,35 +23,23 @@ import { TestControls } from "./test-controls";
 import { Header } from "@/components/ui/header";
 import { createClient } from "@/lib/supabase/client";
 import {
-  leaveQueue,
+  adminQueueQueryKey,
+  fetchAdminQueueEntries,
+} from "@/lib/admin-queue";
+import {
   adminRemoveFromQueue,
   assignPlayersToNextCourt,
   endGameAndReorderQueue,
 } from "@/app/actions/queue";
-import { sendQueueNotification } from "@/app/actions/notifications";
 import type {
   Event,
-  QueueEntry,
   CourtAssignment,
   TeamSize,
   RotationType,
   EventStatus,
-  GroupSize,
-  QueueStatus,
   SkillLevel,
 } from "@/lib/types";
 import type { Database } from "@/supabase/supa-schema";
-
-type QueueEntryRow = Database["public"]["Tables"]["queue_entries"]["Row"];
-type QueueEntryWithUser = QueueEntryRow & {
-  player_names?: unknown; // JSON field that may not be in schema
-  user: {
-    id: string;
-    name: string;
-    email: string;
-    skill_level: string;
-  } | null;
-};
 
 type CourtAssignmentRow =
   Database["public"]["Tables"]["court_assignments"]["Row"];
@@ -114,8 +102,8 @@ export default function AdminEventDetailPage(props: {
 }) {
   const params = use(props.params);
   const { id } = params;
+  const queryClient = useQueryClient();
   const [event, setEvent] = useState<Event | null>(null);
-  const [queue, setQueue] = useState<QueueEntry[]>([]);
   const [assignments, setAssignments] = useState<CourtAssignment[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -178,73 +166,13 @@ export default function AdminEventDetailPage(props: {
     fetchEvent();
   }, [id]);
 
-  const fetchQueue = useCallback(async () => {
-    const supabase = createClient();
-    const { data, error } = await supabase
-      .from("queue_entries")
-      .select(
-        `
-          *,
-          user:users(id, name, email, skill_level)
-        `,
-      )
-      .eq("event_id", id)
-      .order("position");
-
-    if (error) {
-      console.error("Error fetching queue:", error);
-      return;
-    }
-
-    if (data) {
-      const queueEntries: QueueEntry[] = data.map(
-        (entry: QueueEntryWithUser) => {
-          let playerNamesArray: Array<{
-            name: string;
-            skillLevel: string;
-          }> = [];
-          if (entry.player_names) {
-            try {
-              const parsed = entry.player_names as unknown as Array<{
-                name: string;
-                skillLevel: string;
-              }>;
-              playerNamesArray = Array.isArray(parsed) ? parsed : [];
-            } catch {
-              playerNamesArray = [];
-            }
-          }
-
-          return {
-            id: entry.id,
-            eventId: entry.event_id,
-            userId: entry.user_id,
-            groupSize: (entry.group_size || 1) as GroupSize,
-            groupId: entry.group_id || undefined,
-            player_names: playerNamesArray,
-            position: entry.position,
-            status: entry.status as QueueStatus,
-            joinedAt: new Date(entry.joined_at),
-            user: entry.user
-              ? {
-                  id: entry.user.id,
-                  name: entry.user.name,
-                  email: entry.user.email,
-                  skillLevel: entry.user.skill_level as SkillLevel,
-                  isAdmin: false,
-                  createdAt: new Date(),
-                }
-              : undefined,
-          };
-        },
-      );
-      setQueue(queueEntries);
-    }
-  }, [id]);
+  const { data: queue = [] } = useQuery({
+    queryKey: adminQueueQueryKey(id),
+    queryFn: () => fetchAdminQueueEntries(id),
+    enabled: Boolean(id),
+  });
 
   useEffect(() => {
-    void fetchQueue();
-
     const supabase = createClient();
     const channel = supabase
       .channel(`admin-queue-${id}`)
@@ -257,7 +185,9 @@ export default function AdminEventDetailPage(props: {
           filter: `event_id=eq.${id}`,
         },
         () => {
-          void fetchQueue();
+          void queryClient.invalidateQueries({
+            queryKey: adminQueueQueryKey(id),
+          });
         },
       )
       .subscribe();
@@ -265,7 +195,7 @@ export default function AdminEventDetailPage(props: {
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [id, fetchQueue]);
+  }, [id, queryClient]);
 
   // Fetch court assignments
   useEffect(() => {
@@ -505,7 +435,9 @@ export default function AdminEventDetailPage(props: {
         });
       } else {
         toast.success("Player removed from queue");
-        await fetchQueue();
+        await queryClient.invalidateQueries({
+          queryKey: adminQueueQueryKey(id),
+        });
       }
     } catch (err) {
       console.error("❌ [ADMIN PAGE] Exception in handleForceRemove:", err);
@@ -542,7 +474,9 @@ export default function AdminEventDetailPage(props: {
         });
       } else {
         toast.success("Queue cleared successfully");
-        await fetchQueue();
+        await queryClient.invalidateQueries({
+          queryKey: adminQueueQueryKey(id),
+        });
       }
     } catch (err) {
       console.error("Error clearing queue:", err);
@@ -658,7 +592,11 @@ export default function AdminEventDetailPage(props: {
               currentRotationType={event.rotationType}
               currentTeamSize={event.teamSize}
               currentCourtCount={event.courtCount}
-              onQueueUpdated={() => void fetchQueue()}
+              onQueueUpdated={() =>
+                void queryClient.invalidateQueries({
+                  queryKey: adminQueueQueryKey(id),
+                })
+              }
             />
           </div>
         )}

--- a/app/admin/events/[id]/test-controls.tsx
+++ b/app/admin/events/[id]/test-controls.tsx
@@ -35,6 +35,8 @@ interface TestControlsProps {
   currentRotationType: RotationType;
   currentTeamSize: number;
   currentCourtCount: number;
+  /** Called after queue-changing actions so admin UI refreshes without full reload. */
+  onQueueUpdated?: () => void | Promise<void>;
 }
 
 export function TestControls({
@@ -42,6 +44,7 @@ export function TestControls({
   currentRotationType,
   currentTeamSize,
   currentCourtCount,
+  onQueueUpdated,
 }: TestControlsProps) {
   const [loading, setLoading] = useState(false);
   const [rotationType, setRotationType] =
@@ -174,6 +177,7 @@ export function TestControls({
         const groupText =
           addGroupSize === 1 ? "solo player" : `group of ${addGroupSize}`;
         toast.success(`Added ${groupText} to queue`);
+        await onQueueUpdated?.();
       } else {
         toast.error(result.error || "Failed to add users");
       }

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { AdminQueryProvider } from "./query-provider";
 
 export const metadata: Metadata = {
   title: "Admin | Ghost Mammoth PB",
@@ -10,5 +11,5 @@ export default function AdminLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  return <AdminQueryProvider>{children}</AdminQueryProvider>;
 }

--- a/app/admin/query-provider.tsx
+++ b/app/admin/query-provider.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState, type ReactNode } from "react";
+
+export function AdminQueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -301,12 +301,16 @@ export default function EventDetailPage(props: {
     }
   }, [id]);
 
-  // Get current user's queue position
+  // Get current user's queue position (waiting or pending solo)
   const currentUserEntry = queue.find(
-    (e) => e.userId === user?.id && e.status === "waiting"
+    (e) =>
+      e.userId === user?.id &&
+      (e.status === "waiting" || e.status === "pending_solo")
   );
   const userPosition = currentUserEntry?.position || 0;
-  const isUpNext = userPosition > 0 && userPosition <= 4;
+  const isPendingSolo = currentUserEntry?.status === "pending_solo";
+  const isUpNext =
+    !isPendingSolo && userPosition > 0 && userPosition <= 4;
 
   // Check if user is currently playing on a court
   const isCurrentlyPlaying = user
@@ -324,8 +328,9 @@ export default function EventDetailPage(props: {
       )
     : false;
 
-  // Handle position change notifications
+  // Handle position change notifications (only when assignable in line)
   useEffect(() => {
+    if (isPendingSolo) return;
     if (userPosition > 0 && lastPosition > 0 && userPosition < lastPosition) {
       if (userPosition <= 4) {
         sendNotification("up-next", "Almost Your Turn!", {
@@ -342,9 +347,11 @@ export default function EventDetailPage(props: {
     if (userPosition > 0) {
       queueMicrotask(() => setLastPosition(userPosition));
     }
-  }, [userPosition, lastPosition, sendNotification]);
+  }, [userPosition, lastPosition, sendNotification, isPendingSolo]);
 
-  const waitingCount = queue.filter((e) => e.status === "waiting").length;
+  const waitingCount = queue.filter(
+    (e) => e.status === "waiting" || e.status === "pending_solo"
+  ).length;
   const playingCount =
     assignments.filter((a) => !a.endedAt).length * (event?.teamSize || 2) * 2;
 
@@ -358,7 +365,9 @@ export default function EventDetailPage(props: {
     const alreadyInQueue = queue.find(
       (e) =>
         e.userId === user.id &&
-        (e.status === "waiting" || e.status === "playing")
+        (e.status === "waiting" ||
+          e.status === "pending_solo" ||
+          e.status === "playing")
     );
 
     if (alreadyInQueue) {
@@ -539,7 +548,11 @@ export default function EventDetailPage(props: {
 
           {userPosition > 0 && (
             <div className="mb-6">
-              <QueuePositionAlert position={userPosition} isUpNext={isUpNext} />
+              <QueuePositionAlert
+                position={userPosition}
+                isUpNext={isUpNext}
+                isPendingSolo={isPendingSolo}
+              />
             </div>
           )}
 
@@ -630,7 +643,9 @@ export default function EventDetailPage(props: {
               ) : userPosition > 0 ? (
                 <Badge variant="default" className="text-sm">
                   <Bell className="w-3 h-3 mr-1" />
-                  You&apos;re #{userPosition}
+                  {isPendingSolo
+                    ? `Waiting for more solos (#${userPosition})`
+                    : `You're #${userPosition}`}
                 </Badge>
               ) : (
                 <>

--- a/components/queue-list.tsx
+++ b/components/queue-list.tsx
@@ -64,8 +64,12 @@ export function QueueList({
   currentUserId,
   isAdmin = false,
 }: QueueListProps) {
-  const waitingQueue = queue
-    .filter((entry) => entry.status === "waiting")
+  /** Single ordered line: assignable + pending solos (same position ordering). */
+  const lineQueue = queue
+    .filter(
+      (entry) =>
+        entry.status === "waiting" || entry.status === "pending_solo"
+    )
     .sort((a, b) => a.position - b.position);
 
   const pendingStayQueue = isAdmin
@@ -89,10 +93,10 @@ export function QueueList({
     return grouped;
   }
 
-  const groupedQueue = buildGrouped(waitingQueue);
+  const groupedLine = buildGrouped(lineQueue);
   const groupedPending = buildGrouped(pendingStayQueue);
 
-  if (waitingQueue.length === 0 && pendingStayQueue.length === 0) {
+  if (lineQueue.length === 0 && pendingStayQueue.length === 0) {
     return (
       <Card className="border-border bg-card">
         <CardContent className="p-12 text-center">
@@ -135,18 +139,21 @@ export function QueueList({
           })}
         </div>
       )}
-      {groupedQueue.map((item, index) => {
+      {groupedLine.map((item) => {
         const isGroup = Array.isArray(item);
         const entries = isGroup ? item : [item];
         const firstEntry = entries[0];
         const isCurrentUser = entries.some((e) => e.userId === currentUserId);
+        const isPendingSolo = firstEntry.status === "pending_solo";
 
         return (
           <Card
             key={isGroup ? firstEntry.groupId : firstEntry.id}
-            className={`border-border bg-card hover:border-primary/50 transition-colors ${
-              isCurrentUser ? "ring-2 ring-primary" : ""
-            }`}
+            className={`bg-card hover:border-primary/50 transition-colors ${
+              isPendingSolo
+                ? "border-dashed border-sky-500/50 bg-sky-500/5"
+                : "border-border"
+            } ${isCurrentUser ? "ring-2 ring-primary" : ""}`}
           >
             <CardContent className="p-4">
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
@@ -161,6 +168,14 @@ export function QueueList({
                       <p className="font-medium text-foreground">
                         Group of {firstEntry.groupSize || entries.length}
                       </p>
+                      {isPendingSolo && (
+                        <Badge
+                          variant="outline"
+                          className="text-xs shrink-0 border-sky-500/50 text-sky-700 dark:text-sky-300"
+                        >
+                          Waiting for more solo players
+                        </Badge>
+                      )}
                       <Badge variant="outline" className="text-xs shrink-0">
                         {getAverageSkillLevel(
                           firstEntry.player_names,

--- a/components/queue-position-alert.tsx
+++ b/components/queue-position-alert.tsx
@@ -1,20 +1,42 @@
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
-import { Bell, Trophy } from "lucide-react"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Bell, Trophy, Users } from "lucide-react";
 
 interface QueuePositionAlertProps {
-  position: number
-  isUpNext: boolean
+  position: number;
+  isUpNext: boolean;
+  /** Solo is in line but not yet in the assignable pool until another solo joins (or mix changes). */
+  isPendingSolo?: boolean;
 }
 
-export function QueuePositionAlert({ position, isUpNext }: QueuePositionAlertProps) {
+export function QueuePositionAlert({
+  position,
+  isUpNext,
+  isPendingSolo = false,
+}: QueuePositionAlertProps) {
+  if (isPendingSolo) {
+    return (
+      <Alert className="border-dashed border-sky-500/50 bg-sky-500/5">
+        <Users className="w-4 h-4 text-sky-600 dark:text-sky-400" />
+        <AlertTitle className="text-foreground">Waiting for more solo players</AlertTitle>
+        <AlertDescription>
+          You&apos;re #{position} in line. Another solo player needs to join before you
+          can rotate into games with the current mix of pairs, or join with a partner
+          as a duo. An event host can help balance the line.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
   if (isUpNext) {
     return (
       <Alert className="border-primary bg-primary/10">
         <Trophy className="w-4 h-4 text-primary" />
         <AlertTitle className="text-primary">You&apos;re Up Next!</AlertTitle>
-        <AlertDescription>Get ready to play. You&apos;ll be assigned to a court shortly.</AlertDescription>
+        <AlertDescription>
+          Get ready to play. You&apos;ll be assigned to a court shortly.
+        </AlertDescription>
       </Alert>
-    )
+    );
   }
 
   if (position <= 4) {
@@ -22,10 +44,12 @@ export function QueuePositionAlert({ position, isUpNext }: QueuePositionAlertPro
       <Alert className="border-primary/50 bg-primary/5">
         <Bell className="w-4 h-4 text-primary" />
         <AlertTitle className="text-foreground">Almost Your Turn</AlertTitle>
-        <AlertDescription>You&apos;re #{position} in queue. Stay nearby and get ready to play!</AlertDescription>
+        <AlertDescription>
+          You&apos;re #{position} in queue. Stay nearby and get ready to play!
+        </AlertDescription>
       </Alert>
-    )
+    );
   }
 
-  return null
+  return null;
 }

--- a/lib/admin-queue.ts
+++ b/lib/admin-queue.ts
@@ -1,0 +1,87 @@
+import { createClient } from "@/lib/supabase/client";
+import type {
+  QueueEntry,
+  GroupSize,
+  QueueStatus,
+  SkillLevel,
+} from "@/lib/types";
+import type { Database } from "@/supabase/supa-schema";
+
+type QueueEntryRow = Database["public"]["Tables"]["queue_entries"]["Row"];
+type QueueEntryWithUser = QueueEntryRow & {
+  player_names?: unknown;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    skill_level: string;
+  } | null;
+};
+
+export const adminQueueQueryKey = (eventId: string) =>
+  ["admin-queue", eventId] as const;
+
+export async function fetchAdminQueueEntries(
+  eventId: string,
+): Promise<QueueEntry[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("queue_entries")
+    .select(
+      `
+          *,
+          user:users(id, name, email, skill_level)
+        `,
+    )
+    .eq("event_id", eventId)
+    .order("position");
+
+  if (error) {
+    console.error("Error fetching queue:", error);
+    return [];
+  }
+
+  if (!data) {
+    return [];
+  }
+
+  return data.map((entry: QueueEntryWithUser) => {
+    let playerNamesArray: Array<{
+      name: string;
+      skillLevel: string;
+    }> = [];
+    if (entry.player_names) {
+      try {
+        const parsed = entry.player_names as unknown as Array<{
+          name: string;
+          skillLevel: string;
+        }>;
+        playerNamesArray = Array.isArray(parsed) ? parsed : [];
+      } catch {
+        playerNamesArray = [];
+      }
+    }
+
+    return {
+      id: entry.id,
+      eventId: entry.event_id,
+      userId: entry.user_id,
+      groupSize: (entry.group_size || 1) as GroupSize,
+      groupId: entry.group_id || undefined,
+      player_names: playerNamesArray,
+      position: entry.position,
+      status: entry.status as QueueStatus,
+      joinedAt: new Date(entry.joined_at),
+      user: entry.user
+        ? {
+            id: entry.user.id,
+            name: entry.user.name,
+            email: entry.user.email,
+            skillLevel: entry.user.skill_level as SkillLevel,
+            isAdmin: false,
+            createdAt: new Date(),
+          }
+        : undefined,
+    };
+  });
+}

--- a/lib/hooks/use-realtime-queue.ts
+++ b/lib/hooks/use-realtime-queue.ts
@@ -22,7 +22,7 @@ export function useRealtimeQueue(eventId: string) {
         `
         )
         .eq("event_id", eventId)
-        .eq("status", "waiting")
+        .in("status", ["waiting", "pending_solo"])
         .order("position");
 
       if (error) {
@@ -34,6 +34,7 @@ export function useRealtimeQueue(eventId: string) {
           userId: entry.user_id,
           groupId: entry.group_id,
           groupSize: entry.group_size,
+          status: entry.status,
           joinedAt: new Date(entry.joined_at),
         }));
         setQueue(queueWithDates);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,7 @@ export type SkillLevel = "beginner" | "intermediate" | "advanced" | "pro";
 export type EventStatus = "active" | "ended";
 export type QueueStatus =
   | "waiting"
+  | "pending_solo"
   | "playing"
   | "completed"
   | "pending_stay";

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@stripe/stripe-js": "^8.0.0",
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.75.0",
+        "@tanstack/react-query": "^5.99.0",
         "@vercel/analytics": "1.3.1",
         "autoprefixer": "^10.4.20",
         "class-variance-authority": "^0.7.1",
@@ -141,7 +142,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1377,7 +1377,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -2803,7 +2802,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.75.0.tgz",
       "integrity": "sha512-8UN/vATSgS2JFuJlMVr51L3eUDz+j1m7Ww63wlvHLKULzCDaVWYzvacCjBTLW/lX/vedI2LBI4Vg+01G9ufsJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.75.0",
         "@supabase/functions-js": "2.75.0",
@@ -3098,6 +3096,32 @@
         "tailwindcss": "4.1.14"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3214,7 +3238,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3225,7 +3248,6 @@
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3284,7 +3306,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -3805,7 +3826,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4194,7 +4214,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4608,7 +4627,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4772,8 +4790,7 @@
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.5.1.tgz",
       "integrity": "sha512-JUb5+FOHobSiWQ2EJNaueCNT/cQU9L6XWBbWmorWPQT9bkbk+fhsuLr8wWrzXKagO3oWszBO7MSx+GfaRk4E6A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.5.1",
@@ -5020,7 +5037,6 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5207,7 +5223,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5640,7 +5655,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7057,7 +7071,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
       "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
@@ -7432,7 +7445,6 @@
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -7475,7 +7487,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7563,7 +7574,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7594,7 +7604,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7607,7 +7616,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
       "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8460,8 +8468,7 @@
       "version": "4.1.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
       "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -8550,7 +8557,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8716,7 +8722,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9116,7 +9121,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
       "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@stripe/stripe-js": "^8.0.0",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.75.0",
+    "@tanstack/react-query": "^5.99.0",
     "@vercel/analytics": "1.3.1",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
Queue fairness — Fixed assign-next tie-breaking so we prefer groups earlier in line (true FIFO). Stops the same court from being refilled from the back of the ordered list when multiple valid full-court packs exist (notably after rotate-all).

Test data — Dummy partner names are now leader-scoped (e.g. Alex's friend A) instead of generic Friend A, so groups are easier to spot in screenshots.

Solo vs. duos — Added pending_solo: a lone solo who can’t be part of any full court with the current mix (e.g. only duos) stays out of the assignable pool until another solo joins or the line changes. UI shows them in the same ordered list with dashed styling and short copy; assign still only uses waiting.

Housekeeping — Reconcile runs on join/leave/end game/assign/admin remove; line positions compact waiting + pending_solo together. 